### PR TITLE
Operators revision

### DIFF
--- a/docs/syntax_specification.ebnf
+++ b/docs/syntax_specification.ebnf
@@ -107,8 +107,10 @@ binaryOrExpression = binaryAndExpression, { ( "||" ), binaryAndExpression };
 (* Ternary *)
 ternaryExpression = binaryOrExpression, [ "?", [ expression ], ":", expression ];
 
+rangeExpression = ternaryExpression, { ( ".." | "..=" ), ternaryExpression }
+
 (* Assignment *)
-binaryAssignmentExpression = ternaryExpression, [ ( "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "&&=" | "||=" | "^=" | "%=" | "<<=" | ">>=" | "<>" ), binaryAssignmentExpression ];
+binaryAssignmentExpression = rangeExpression, [ ( "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "&&=" | "||=" | "^=" | "%=" | "<<=" | ">>=" | "<>" ), binaryAssignmentExpression ];
 
 (* Comma *)
 commaExpression = binaryAssignmentExpression, { ",", binaryAssignmentExpression };

--- a/include/segvc/expressions.hxx
+++ b/include/segvc/expressions.hxx
@@ -52,6 +52,8 @@ enum class OPE {
 	COMRT,  // >
 	COMLTE, // <=
 	COMRTE, // >=
+	RANGEI, // ..
+	RANGEE, // ..=
 
 	// Unary Operators
 	ADDR, // &x

--- a/include/segvc/expressions.hxx
+++ b/include/segvc/expressions.hxx
@@ -53,10 +53,9 @@ enum class OPE {
 	COMLTE, // <=
 	COMRTE, // >=
 
+	// Unary Operators
 	ADDR, // &x
 	DEREF, // *x
-
-	// Unary Operators
 	NOT, // !
 	NEG, // ~x
 	INCB, // ++x

--- a/include/segvc/tokens.hxx
+++ b/include/segvc/tokens.hxx
@@ -105,6 +105,9 @@ typedef enum {
 	TOK_COMMA,       // ,
 	TOK_DOT,         // .
 
+	TOK_OP_RANGE_EXCLUSIVE,     // ..
+	TOK_OP_RANGE_INCLUSIVE,     // ..=
+
 	TOK_KEY_RETURN,
 
 	TOK_SYS_SKIP,

--- a/src/tokenizer/proc/symbol.cpp
+++ b/src/tokenizer/proc/symbol.cpp
@@ -85,8 +85,12 @@ namespace segvc {
 	                type = Tokens::TOK_DEC;
 	        else if(name == "->")
 	                type = Tokens::TOK_ARROW;
+	        else if(name == "..")
+	        	type = Tokens::TOK_OP_RANGE_EXCLUSIVE;
+	        else if(name == "..=")
+	        	type = Tokens::TOK_OP_RANGE_INCLUSIVE;
 	        else if(name == "...")
-	                type = Tokens::TOK_ELLIPSIS;
+	        	type = Tokens::TOK_ELLIPSIS;
 	        else if(name == "+=")
 	                type = Tokens::TOK_ASSIGN_PLUS;
 	        else if(name == "-=")

--- a/src/tokenizer/read/symbol.cpp
+++ b/src/tokenizer/read/symbol.cpp
@@ -9,83 +9,82 @@
 #include <unordered_map>
 
 namespace segvc {
+    Token Tokenizer::readSymbol(std::istream &in) {
+        Token tok;
+        tok.startOffset = tok.endOffset = in.tellg();
+        tok.line = line;
+        tok.column = tok.startOffset - line_beg + 1;
 
-	Token Tokenizer::readSymbol(std::istream& in) {
-		Token tok;
-	        tok.startOffset = tok.endOffset = in.tellg();
-	        tok.line = line;
-	        tok.column = tok.startOffset - line_beg + 1;
+        char p = in.get();
+        tok.name = std::string(1, p);
 
-		char p = in.get();
-	        tok.name = std::string(1, p);
+        if (p == '+') {
+            p = in.peek();
+            switch (p) {
+                case '+':
+                case '=':
+                    tok.name += in.get();
+                    break;
+            }
+        } else if (p == '-') {
+            p = in.peek();
+            switch (p) {
+                case '-':
+                case '>':
+                case '=':
+                    tok.name += in.get();
+                    break;
+            }
+        } else
+            switch (p) {
+                case '/':
+                    p = in.peek();
+                    if (p == '=' || p == '/' || p == '*')
+                        tok.name += in.get();
+                    break;
+                case '*':
+                case '%':
+                case '^':
+                    p = in.peek();
+                    if (p == '=')
+                        tok.name += in.get();
+                    break;
+                case '&':
+                    p = in.peek();
+                    if (p == '&' || p == '=')
+                        tok.name += in.get();
+                    break;
+                case '|':
+                    p = in.peek();
+                    if (p == '|' || p == '=')
+                        tok.name += in.get();
+                    break;
+                case '.':
+                    p = in.peek();
+                    if (p == '.') {
+                        tok.name += in.get();
+                        if (p == '.')
+                            tok.name += in.get();
+                    }
+                    break;
+                case '<':
+                    p = in.peek();
+                    if (p == '<') {
+                        tok.name += in.get();
+                        if (p == '=')
+                            tok.name += in.get();
+                    } else if (p == '>') tok.name += in.get();
+                    break;
+                case '>':
+                    p = in.peek();
+                    if (p == '>') {
+                        tok.name += in.get();
+                        if (p == '=')
+                            tok.name += in.get();
+                    }
+                    break;
+            }
 
-		if(p == '+') {
-			p = in.peek();
-			switch(p) {
-				case '+':
-				case '=':
-				tok.name += in.get();
-				break;
-			}
-		} else if(p == '-') {
-	                p = in.peek();
-	                switch(p) {
-	                        case '-':
-				case '>':
-	                        case '=':
-	                        tok.name += in.get();
-	                        break;
-	                }
-	        } else switch(p) {
-			case '/':
-	        	        p = in.peek();
-				if(p == '=' || p == '/' || p == '*')
-	                        	tok.name += in.get();
-				break;
-			case '*':
-			case '%':
-			case '^':
-	        	        p = in.peek();
-				if(p == '=')
-	                        	tok.name += in.get();
-				break;
-			case '&':
-	                        p = in.peek();
-	                        if(p == '&' || p == '=')
-	                                tok.name += in.get();
-	                        break;
-	                case '|':
-	                        p = in.peek();
-	                        if(p == '|' || p == '=')
-	                                tok.name += in.get();
-	                        break;
-			case '.':
-	                        p = in.peek();
-	                        if(p == '.') {
-	                                tok.name += in.get();
-					if(p == '.')
-	                                	tok.name += in.get();
-				}
-	                        break;
-			case '<':
-	                        p = in.peek();
-	                        if(p == '<') {
-	                                tok.name += in.get();
-	                                if(p == '=')
-	                                        tok.name += in.get();
-	                        } else if(p == '>') tok.name += in.get();
-	                        break;
-			case '>':
-	                        p = in.peek();
-	                        if(p == '>') {
-	                                tok.name += in.get();
-	                                if(p == '=')
-	                                        tok.name += in.get();
-	                        }
-	                        break;
-	        }
-
-		return tok;
-	}
-
+        return tok;
+    }
 }

--- a/src/tokenizer/read/symbol.cpp
+++ b/src/tokenizer/read/symbol.cpp
@@ -63,6 +63,7 @@ namespace segvc {
                     p = in.peek();
                     if (p == '.') {
                         tok.name += in.get();
+                        p = in.peek();
                         if (p == '.')
                             tok.name += in.get();
                     }
@@ -71,6 +72,7 @@ namespace segvc {
                     p = in.peek();
                     if (p == '<') {
                         tok.name += in.get();
+                        p = in.peek();
                         if (p == '=')
                             tok.name += in.get();
                     } else if (p == '>') tok.name += in.get();
@@ -79,6 +81,7 @@ namespace segvc {
                     p = in.peek();
                     if (p == '>') {
                         tok.name += in.get();
+                        p = in.peek();
                         if (p == '=')
                             tok.name += in.get();
                     }

--- a/src/tokenizer/read/symbol.cpp
+++ b/src/tokenizer/read/symbol.cpp
@@ -64,8 +64,7 @@ namespace segvc {
                     if (p == '.') {
                         tok.name += in.get();
                         p = in.peek();
-                        if (p == '.')
-                            tok.name += in.get();
+                        if ( p == '.' || p == '=' ) tok.name += in.get();
                     }
                     break;
                 case '<':

--- a/src/tokenparser/eval/eval.cpp
+++ b/src/tokenparser/eval/eval.cpp
@@ -36,6 +36,13 @@ namespace segvc {
 				{Tokens::TOK_ASSIGN_SWAP, OPE::ASSSWAP}
 			}
 		},
+	{ // OP: ||
+			&Tokenparser::evalBinaryLeftToRight,
+			{
+				{Tokens::TOK_OP_RANGE_EXCLUSIVE, OPE::RANGEE},
+				{Tokens::TOK_OP_RANGE_INCLUSIVE, OPE::RANGEI}
+			},
+		},
 
 		// TODO: Going to add a special ternary evaulator dunction here
 


### PR DESCRIPTION
This PR resolves two issues.

First of all we just implemented range operators, their priority level is between ternary and assignment operators. There's two ( `..` and `..=` ) operators. First one means a to the b while b is exclusive. Second one is also a to b but b inclusive. And this closing #10 

Also this PR solves bug that causes trouble while processing `<<=`, `>>=` and `...` operators. And this closing #27 